### PR TITLE
Make it possible to set the display name for a build

### DIFF
--- a/lib/Artifact.ts
+++ b/lib/Artifact.ts
@@ -50,7 +50,7 @@ export interface ArtifactRegistration {
 
 /**
  * This goal is fulfilled by an OnImageLinked event subscription. The Build goal will
- * cause such an event being emitted, but external CI systems can trigger the goal
+ * cause such an event to be emitted, but external CI systems can trigger the goal
  * fulfillment as well. On fulfillment, the external URL for the artifact will be
  * put on the goal instance and shown in the client.
  *

--- a/lib/Build.ts
+++ b/lib/Build.ts
@@ -79,8 +79,8 @@ export class Build
 
         super({
             ...BuildGoal.definition,
-            ...getGoalDefinitionFrom(goalDetailsOrUniqueName, DefaultGoalNameGenerator.generateName("build")),
             displayName: "build",
+            ...getGoalDefinitionFrom(goalDetailsOrUniqueName, DefaultGoalNameGenerator.generateName("build")),
         }, ...dependsOn);
     }
 


### PR DESCRIPTION
Is there a reason that a Build needs to always have this display name?